### PR TITLE
Changed the way the stacks are z-indexed.

### DIFF
--- a/js/jquery.stacks.js
+++ b/js/jquery.stacks.js
@@ -1,32 +1,34 @@
 (function ( $ ) {
   $.fn.stack = function() {
+
       this.css( "position", "fixed" );
-      var elemCount = 0;
-      var elems = [];
-      var currentElem = 0;
-      var prevHeight = 0;
+
+      var elemCount = this.length,
+          elems = [],
+          currentElem = 0,
+          prevHeight = 0;
+
       this.each(function() {
-        $('body').css('height', $('body').outerHeight() + $(this).outerHeight());
-        $(this).css('z-index', elemCount);
-        elems.push($(this));
-        console.log(elemCount);
+        $( 'body' ).css( 'height' , $( 'body' ).outerHeight() + $( this ).outerHeight());
+        $( this ).css( 'z-index' , elemCount);
+        elems.push( $( this ) );
         elemCount--;
       });
 
-      $(window).scroll(function() {
-        elems[currentElem].css('top', - $(window).scrollTop() + prevHeight);
-          if ($(window).scrollTop() > 0 && $(window).scrollTop() < $(document).outerHeight()) {
+      $( window ).scroll(function() {
+        elems[currentElem].css('top', - $( window ).scrollTop() + prevHeight);
+          if ( $( window ).scrollTop() > 0 && $( window ).scrollTop() < $( document ).outerHeight() ) {
             checkElems();
           }
       });
 
       function checkElems() {
-        if ($(window).scrollTop() > elems[currentElem].outerHeight() + prevHeight) {
+        if ( $( window ).scrollTop() > elems[currentElem].outerHeight() + prevHeight ) {
           prevHeight = prevHeight + elems[currentElem].outerHeight();
           currentElem++;
         }
 
-        if ($(window).scrollTop() < prevHeight) {
+        if ( $( window) .scrollTop() < prevHeight ) {
           prevHeight = prevHeight - elems[currentElem].outerHeight();
           currentElem--;
         }


### PR DESCRIPTION
- This z-index change stops us from using a negative z-index to stack the elements. Negative z-index is a UX issue, because users can't select text or images on negatively z-indexed containers. Instead, we count all of the items and then index them counting down from the total amount of elements (n-1) rather than negatively from 0 (0-1). 
- Cleaned up the code to match the jQuery style guide (https://contribute.jquery.org/style-guide/js/).
- Also removed the console.log
